### PR TITLE
Enable FAI measure on first video load

### DIFF
--- a/dynaface-app/tab_analyze_video.py
+++ b/dynaface-app/tab_analyze_video.py
@@ -570,6 +570,10 @@ gesture you wish to analyze."""
             self.create_graphic(buffer=self._face.render_img, msg_overlay=True)
             self._view.grabGesture(Qt.GestureType.PinchGesture)
             self._view.installEventFilter(self)
+            # Auto-enable the FAI measure once the UI tree exists and a frame
+            # has been loaded. This ensures the checkbox state is properly
+            # synchronized before the face is analyzed.
+            self.enable_measure("FAI")
             self.update_face()
             logger.debug("Done, display first video frame on load")
             # Auto fit


### PR DESCRIPTION
## Summary
- auto-check the FAI measure when the first frame is loaded

## Testing
- `python3 -m py_compile dynaface-app/tab_analyze_video.py`
